### PR TITLE
sfneal/models v2.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,8 @@ All notable changes to `address` will be documented in this file
 
 ## 1.1.0 - 2021-04-06
 - fix sfneal/models version constraint (^1.0)
+
+
+## 1.2.0 - 2021-04-07
+- bump min sfneal/models version to v2.0
+- refactor use of `AbstractModel` to `Model`

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/models": "^1.0",
+        "sfneal/models": "^2.0",
         "sfneal/string-helpers": ">=1.0.1"
     },
     "require-dev": {

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -5,7 +5,7 @@ namespace Sfneal\Address\Models;
 use Database\Factories\AddressFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Sfneal\Address\Builders\AddressBuilder;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
@@ -66,7 +66,7 @@ class Address extends AbstractModel
     /**
      * Get the owning addressable model.
      *
-     * @return MorphTo|Model
+     * @return MorphTo|AbstractModel|EloquentModel
      */
     public function addressable()
     {

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -10,10 +10,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Sfneal\Address\Builders\AddressBuilder;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Strings\StringHelpers;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 use Sfneal\Models\Traits\CityStateAccessors;
 
-class Address extends AbstractModel
+class Address extends Model
 {
     use CityStateAccessors;
     use HasFactory;
@@ -66,7 +66,7 @@ class Address extends AbstractModel
     /**
      * Get the owning addressable model.
      *
-     * @return MorphTo|AbstractModel|EloquentModel
+     * @return MorphTo|Model|EloquentModel
      */
     public function addressable()
     {

--- a/src/Models/Traits/SaveAddressTrait.php
+++ b/src/Models/Traits/SaveAddressTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Address\Models\Traits;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Sfneal\Address\Models\Address;
 
 trait SaveAddressTrait
@@ -14,7 +14,7 @@ trait SaveAddressTrait
      *
      * @param string $key Request key
      *
-     * @return Model|false
+     * @return EloquentModel|false
      */
     private function createAddress(string $key = 'address')
     {
@@ -38,7 +38,7 @@ trait SaveAddressTrait
      *
      * @param string $key
      *
-     * @return bool|false|Model|mixed
+     * @return bool|false|EloquentModel|mixed
      */
     private function createOrUpdateAddress(string $key = 'address')
     {

--- a/tests/Models/People.php
+++ b/tests/Models/People.php
@@ -4,13 +4,13 @@ namespace Sfneal\Address\Tests\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Tests\Factories\PeopleFactory;
 use Sfneal\Builders\QueryBuilder;
+use Sfneal\Models\AbstractModel;
 
-class People extends Model
+class People extends AbstractModel
 {
     use HasFactory;
 

--- a/tests/Models/People.php
+++ b/tests/Models/People.php
@@ -8,9 +8,9 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Tests\Factories\PeopleFactory;
 use Sfneal\Builders\QueryBuilder;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 
-class People extends AbstractModel
+class People extends Model
 {
     use HasFactory;
 


### PR DESCRIPTION
- bump min sfneal/models version to v2.0
- refactor use of `AbstractModel` to `Model`