### PR TITLE
`address_full` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ All notable changes to `address` will be documented in this file
 
 ## 1.2.2 - 2021-04-13
 - add `address_full` attribute to `Address` model that returns a full address string
+- fix issue with `AddressFactory` polymorphic relationship definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,7 @@ All notable changes to `address` will be documented in this file
 ## 1.2.1 - 2021-04-08
 - optimize Travis CI config & enable code coverage uploading
 - bump sfneal/models min version
+
+
+## 1.2.2 - 2021-04-13
+- add `address_full` attribute to `Address` model that returns a full address string

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Sfneal\Address\Models\Address;
-use Sfneal\Address\Tests\Models\People;
 
 class AddressFactory extends Factory
 {
@@ -29,8 +28,6 @@ class AddressFactory extends Factory
             'city' => $this->faker->city,
             'state' => $this->faker->state,
             'zip' => $this->faker->postcode,
-            'addressable_id' => People::factory(),
-            'addressable_type' => People::class,
         ];
     }
 }

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -108,8 +108,9 @@ class Address extends Model
     public function getAddressFullAttribute(): string
     {
         // Include the second line address if set
-        $address = "{$this->address_1}, " . (isset($this->address_2) ? "{$this->address_2}, " : '');
-        return $address . "{$this->city}, {$this->state} {$this->zip}";
+        $address = "{$this->address_1}, ".(isset($this->address_2) ? "{$this->address_2}, " : '');
+
+        return $address."{$this->city}, {$this->state} {$this->zip}";
     }
 
     /**

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -99,6 +99,20 @@ class Address extends Model
     }
 
     /**
+     * Retrieve the 'address_full' attribute.
+     *
+     *  - returns a full address string that includes address, city, state & zip
+     *
+     * @return string
+     */
+    public function getAddressFullAttribute(): string
+    {
+        // Include the second line address if set
+        $address = "{$this->address_1}, " . (isset($this->address_2) ? "{$this->address_2}, " : '');
+        return $address . "{$this->city}, {$this->state} {$this->zip}";
+    }
+
+    /**
      * Set the 'address_1' attribute.
      *
      * @param $value

--- a/tests/FactoriesTest.php
+++ b/tests/FactoriesTest.php
@@ -33,6 +33,7 @@ class FactoriesTest extends TestCase
         $this->assertIsString($this->model->city);
         $this->assertIsString($this->model->state);
         $this->assertIsString($this->model->zip);
+        $this->assertIsString($this->model->address_full);
     }
 
     /** @test */

--- a/tests/FactoriesTest.php
+++ b/tests/FactoriesTest.php
@@ -37,6 +37,18 @@ class FactoriesTest extends TestCase
     }
 
     /** @test */
+    public function address_attributes_are_correct_types()
+    {
+        // Name attributes
+        $this->assertIsString($this->model->address_full);
+        $this->assertStringContainsString(', ', $this->model->address_full);
+        $this->assertStringContainsString($this->model->address_1, $this->model->address_full);
+        $this->assertStringContainsString($this->model->city, $this->model->address_full);
+        $this->assertStringContainsString($this->model->state, $this->model->address_full);
+        $this->assertStringContainsString($this->model->zip, $this->model->address_full);
+    }
+
+    /** @test */
     public function people_fillables_are_correct_types()
     {
         $this->assertIsString($this->model->addressable->name_first);

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -48,5 +48,6 @@ class MigrationsTest extends TestCase
         $this->assertSame($newAddress->city, 'Boston');
         $this->assertSame($newAddress->state, 'MA');
         $this->assertSame($newAddress->zip, '12345');
+        $this->assertSame($newAddress->address_full, '123 Main Street, Boston, MA 12345');
     }
 }


### PR DESCRIPTION
- add `address_full` attribute to `Address` model that returns a full address string
- fix issue with `AddressFactory` polymorphic relationship definition