### PR TITLE
`addressable()` return type hinting & sfneal/mock-models dev requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 
 env:
     matrix:
-        - COMPOSER_FLAGS="--prefer-lowest -W"
-        - COMPOSER_FLAGS=" -W"
+        - COMPOSER_FLAGS="--prefer-lowest"
+        - COMPOSER_FLAGS=""
 
 jobs:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 
 env:
     matrix:
-        - COMPOSER_FLAGS="--prefer-lowest"
-        - COMPOSER_FLAGS=""
+        - COMPOSER_FLAGS="--prefer-lowest -W"
+        - COMPOSER_FLAGS=" -W"
 
 jobs:
     allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,8 @@ All notable changes to `address` will be documented in this file
 ## 1.2.3 - 2021-04-20
 - bump min sfneal/mock-models dev requirement
 - add use of sfneal/mock-models test utilities & mock models
+
+
+## 1.2.4 - 2021-04-22
+- fix model factory creation to create 20 `People` each with an `Address`
+- fix `addressable()` method return type hinting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,4 @@ All notable changes to `address` will be documented in this file
 ## 1.2.4 - 2021-04-22
 - fix model factory creation to create 20 `People` each with an `Address`
 - fix `addressable()` method return type hinting
+- fix issues with sfneal/mock-models dev requirement

--- a/composer.json
+++ b/composer.json
@@ -52,5 +52,6 @@
     },
     "config": {
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
             "role": "Developer"
         }
     ],
+    "version": "1.2.4",
     "require": {
         "php": ">=7.3",
         "sfneal/models": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.2.2"
+        "sfneal/mock-models": "dev-dev"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": "0.2.1"
+        "sfneal/mock-models": ">=0.2.2"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.2.1"
+        "sfneal/mock-models": ">=0.2.2"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": "dev-dev"
+        "sfneal/mock-models": "0.2.1"
     },
     "extra": {
         "laravel": {

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -5,7 +5,6 @@ namespace Sfneal\Address\Models;
 use Database\Factories\AddressFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Sfneal\Address\Builders\AddressBuilder;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
@@ -66,9 +65,9 @@ class Address extends Model
     /**
      * Get the owning addressable model.
      *
-     * @return MorphTo|Model|EloquentModel
+     * @return MorphTo
      */
-    public function addressable()
+    public function addressable(): MorphTo
     {
         return $this->morphTo();
     }

--- a/tests/FactoriesTest.php
+++ b/tests/FactoriesTest.php
@@ -8,11 +8,8 @@ use Sfneal\Testing\Utils\Interfaces\Factory\FillablesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\RelationshipAttributesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\RelationshipFillablesTest;
 
-class FactoriesTest extends TestCase implements
-    FillablesTest,
-                                                AttributesTest,
-                                                RelationshipAttributesTest,
-                                                RelationshipFillablesTest
+class FactoriesTest extends TestCase
+    implements FillablesTest, AttributesTest, RelationshipAttributesTest, RelationshipFillablesTest
 {
     /**
      * @var Address

--- a/tests/FactoriesTest.php
+++ b/tests/FactoriesTest.php
@@ -8,8 +8,7 @@ use Sfneal\Testing\Utils\Interfaces\Factory\FillablesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\RelationshipAttributesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\RelationshipFillablesTest;
 
-class FactoriesTest extends TestCase
-    implements FillablesTest, AttributesTest, RelationshipAttributesTest, RelationshipFillablesTest
+class FactoriesTest extends TestCase implements FillablesTest, AttributesTest, RelationshipAttributesTest, RelationshipFillablesTest
 {
     /**
      * @var Address

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,9 +55,9 @@ class TestCase extends OrchestraTestCase
         parent::setUp();
 
         // Create model factories
-        Address::factory()
+        People::factory()
             ->count(20)
-            ->for(People::factory(), 'addressable')
+            ->has(Address::factory())
             ->create();
     }
 }


### PR DESCRIPTION
- fix model factory creation to create 20 `People` each with an `Address`
- fix `addressable()` method return type hinting
- fix issues with sfneal/mock-models dev requirement