### PR TITLE
Fix issues with sfneal/mock-models install in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 
 env:
     matrix:
-        - COMPOSER_FLAGS="--prefer-lowest -W"
-        - COMPOSER_FLAGS=" -W"
+        - COMPOSER_FLAGS="--prefer-lowest"
+        - COMPOSER_FLAGS=""
 
 jobs:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 
 env:
     matrix:
-        - COMPOSER_FLAGS="--prefer-lowest"
-        - COMPOSER_FLAGS=""
+        - COMPOSER_FLAGS="--prefer-lowest -W"
+        - COMPOSER_FLAGS=" -W"
 
 jobs:
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -52,5 +52,6 @@
     },
     "config": {
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
             "role": "Developer"
         }
     ],
+    "version": "1.2.4",
     "require": {
         "php": ">=7.3",
         "sfneal/models": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.2.2"
+        "sfneal/mock-models": "dev-dev"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": "0.2.1"
+        "sfneal/mock-models": ">=0.2.2"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": "dev-dev"
+        "sfneal/mock-models": "0.2.1"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
 - add 'version' key to composer.json that overrides the root repo version & allows sfneal/mock-models installs