### PR TITLE
Test suite refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,10 @@ All notable changes to `address` will be documented in this file
 - fix model factory creation to create 20 `People` each with an `Address`
 - fix `addressable()` method return type hinting
 - fix issues with sfneal/mock-models dev requirement
+
+
+## 1.2.5 - 2021-07-12
+- refactor test classes to `Feature` test namespace
+- make `AddressTest` unit test for testing the `Address` model
+- make `AddressBuilderTest` & add sfneal/datum to dev requirements
+- make `AddressMutatorsTest` for testing setting city, state pairs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,4 @@ All notable changes to `address` will be documented in this file
 - make `AddressTest` unit test for testing the `Address` model
 - make `AddressBuilderTest` & add sfneal/datum to dev requirements
 - make `AddressMutatorsTest` for testing setting city, state pairs
+- bump min sfneal/mock-models composer package version to v0.6

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.2.2"
+        "sfneal/mock-models": ">=0.2.2",
+        "sfneal/datum": ">=1.4.1"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.2.2",
+        "sfneal/mock-models": ">=0.6",
         "sfneal/datum": ">=1.4.1"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
             "role": "Developer"
         }
     ],
-    "version": "1.2.4",
+    "version": "1.2.5",
     "require": {
         "php": ">=7.3",
         "sfneal/models": "^2.2",

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -145,7 +145,7 @@ class Address extends Model
         if (isset($value) && (new StringHelpers($value))->inString(',')) {
             [$city, $state] = explode(',', $value);
             $this->attributes['city'] = ucfirst(trim($city));
-            $this->setStateAttribute($state);
+            $this->setStateAttribute(trim($state));
         } else {
             $this->attributes['city'] = ucfirst(trim($value));
         }

--- a/tests/Feature/AddressBuilderTest.php
+++ b/tests/Feature/AddressBuilderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Sfneal\Address\Tests\Feature;
+
+
+use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
+use Sfneal\Queries\RandomModelAttributeQuery;
+
+class AddressBuilderTest extends TestCase
+{
+    /** @test */
+    public function whereType()
+    {
+        $attribute = 'addressable_type';
+        $value = (new RandomModelAttributeQuery(Address::class, $attribute))->execute();
+        $model = Address::query()->whereType($value)->get();
+
+        $this->assertContains($value, $model->pluck($attribute));
+    }
+}

--- a/tests/Feature/AddressBuilderTest.php
+++ b/tests/Feature/AddressBuilderTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Address\Tests\Feature;
-
 
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Tests\TestCase;

--- a/tests/Feature/AddressMutatorsTest.php
+++ b/tests/Feature/AddressMutatorsTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Address\Tests\Feature;
-
 
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Tests\TestCase;
@@ -17,7 +15,7 @@ class AddressMutatorsTest extends TestCase
         $address = Address::query()->find($address_id);
 
         $address->update([
-            'city' => 'Boston, MA'
+            'city' => 'Boston, MA',
         ]);
 
         $updatedAddress = Address::query()->find($address_id);

--- a/tests/Feature/AddressMutatorsTest.php
+++ b/tests/Feature/AddressMutatorsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Sfneal\Address\Tests\Feature;
+
+
+use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
+use Sfneal\Queries\RandomModelAttributeQuery;
+
+class AddressMutatorsTest extends TestCase
+{
+    /** @test */
+    public function set_city_state()
+    {
+        $address_id = (new RandomModelAttributeQuery(Address::class, 'address_id'))->execute();
+        $address = Address::query()->find($address_id);
+
+        $address->update([
+            'city' => 'Boston, MA'
+        ]);
+
+        $updatedAddress = Address::query()->find($address_id);
+        $this->assertNotNull($updatedAddress);
+        $this->assertInstanceOf(Address::class, $updatedAddress);
+        $this->assertSame('Boston', $updatedAddress->city);
+        $this->assertSame('MA', $updatedAddress->state);
+    }
+}

--- a/tests/Feature/FactoriesTest.php
+++ b/tests/Feature/FactoriesTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Sfneal\Address\Tests;
+namespace Sfneal\Address\Tests\Feature;
 
 use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
 use Sfneal\Testing\Utils\Interfaces\Factory\AttributesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\FillablesTest;
 use Sfneal\Testing\Utils\Interfaces\Factory\RelationshipAttributesTest;

--- a/tests/Feature/MigrationsTest.php
+++ b/tests/Feature/MigrationsTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Sfneal\Address\Tests;
+namespace Sfneal\Address\Tests\Feature;
 
 use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
 
 class MigrationsTest extends TestCase
 {

--- a/tests/Feature/RelationshipsTest.php
+++ b/tests/Feature/RelationshipsTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Sfneal\Address\Tests;
+namespace Sfneal\Address\Tests\Feature;
 
 use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
 use Sfneal\Testing\Models\People;
 
 class RelationshipsTest extends TestCase

--- a/tests/Unit/AddressTest.php
+++ b/tests/Unit/AddressTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Address\Tests\Unit;
-
 
 use Database\Factories\AddressFactory;
 use Sfneal\Address\Builders\AddressBuilder;

--- a/tests/Unit/AddressTest.php
+++ b/tests/Unit/AddressTest.php
@@ -1,0 +1,96 @@
+<?php
+
+
+namespace Sfneal\Address\Tests\Unit;
+
+
+use Database\Factories\AddressFactory;
+use Sfneal\Address\Builders\AddressBuilder;
+use Sfneal\Address\Models\Address;
+use Sfneal\Address\Tests\TestCase;
+use Sfneal\Queries\RandomModelAttributeQuery;
+use Sfneal\Testing\Models\People;
+use Sfneal\Testing\Utils\Interfaces\CrudModelTest;
+use Sfneal\Testing\Utils\Interfaces\ModelBuilderTest;
+use Sfneal\Testing\Utils\Interfaces\ModelFactoryTest;
+use Sfneal\Testing\Utils\Interfaces\ModelRelationshipsTest;
+
+class AddressTest extends TestCase implements CrudModelTest, ModelBuilderTest, ModelFactoryTest, ModelRelationshipsTest
+{
+    /** @test */
+    public function records_can_be_created()
+    {
+        $address = Address::factory()->create();
+
+        $this->assertNotNull($address);
+        $this->assertInstanceOf(Address::class, $address);
+    }
+
+    /** @test */
+    public function records_can_be_updated()
+    {
+        $data = [
+            'address_1' => '100 Legends Way',
+            'address_2' => null,
+            'city' => 'Boston',
+            'state' => 'MA',
+            'zip' => '02114',
+        ];
+        $address_id = (new RandomModelAttributeQuery(Address::class, 'address_id'))->execute();
+        $address = Address::query()->find($address_id);
+        $address->update($data);
+
+        $updatedAddress = Address::query()->find($address_id);
+        $this->assertNotNull($updatedAddress);
+        $this->assertInstanceOf(Address::class, $updatedAddress);
+        $this->assertSame($address->getKey(), $updatedAddress->getKey());
+        $this->assertEquals($address->created_at, $updatedAddress->created_at);
+        $this->assertEquals($address->updated_at, $updatedAddress->updated_at);
+
+        foreach ($data as $key => $value) {
+            $this->assertSame($value, $updatedAddress->{$key});
+        }
+
+        $this->assertSame('100 Legends Way, Boston, MA 02114', $updatedAddress->address_full);
+    }
+
+    /** @test */
+    public function records_can_be_deleted()
+    {
+        $address_id = (new RandomModelAttributeQuery(Address::class, 'address_id'))->execute();
+        $address = Address::query()->find($address_id);
+
+        $address->delete();
+
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertTrue($address->wasDeleted());
+        $this->assertNull(Address::query()->find($address_id));
+    }
+
+    /** @test */
+    public function builder_is_accessible()
+    {
+        $builder = Address::query();
+
+        $this->assertInstanceOf(AddressBuilder::class, $builder);
+        $this->assertIsString($builder->toSql());
+    }
+
+    /** @test */
+    public function factory_is_accessible()
+    {
+        $factory = Address::factory();
+
+        $this->assertInstanceOf(AddressFactory::class, $factory);
+    }
+
+    /** @test */
+    public function relationships_are_accessible()
+    {
+        $address_id = (new RandomModelAttributeQuery(Address::class, 'address_id'))->execute();
+        $address = Address::query()->find($address_id);
+
+        $this->assertNotNull($address->addressable);
+        $this->assertInstanceOf(People::class, $address->addressable);
+    }
+}


### PR DESCRIPTION
- refactor test classes to `Feature` test namespace
- make `AddressTest` unit test for testing the `Address` model
- make `AddressBuilderTest` & add sfneal/datum to dev requirements
- make `AddressMutatorsTest` for testing setting city, state pairs
- bump min sfneal/mock-models composer package version to v0.6