### PR TITLE
Cleanup composer requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,8 @@ All notable changes to `address` will be documented in this file
 
 ## 1.2.6 - 2021-07-16
 - fix issue with `AddressServiceProvider` database migration path
+
+ 
+## 1.2.7 - 2021-07-30
+- add sfneal/array-helpers explicit composer requirement (previously was indirectly required by sfneal/string-helpers)
+- fix sfneal/string-helpers dependency to prevent v2.0 upgrades

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
     "version": "1.2.5",
     "require": {
         "php": ">=7.3",
+        "sfneal/array-helpers": "^1.3",
         "sfneal/models": "^2.2",
-        "sfneal/string-helpers": ">=1.0.1"
+        "sfneal/string-helpers": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": ">=6.7.1",


### PR DESCRIPTION
- add sfneal/array-helpers explicit composer requirement (previously was indirectly required by sfneal/string-helpers)
- fix sfneal/string-helpers dependency to prevent v2.0 upgrades