### PR TITLE
Fix issue with sfneal/mock-models package interdependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,8 @@ All notable changes to `address` will be documented in this file
 ## 1.2.7 - 2021-07-30
 - add sfneal/array-helpers explicit composer requirement (previously was indirectly required by sfneal/string-helpers)
 - fix sfneal/string-helpers dependency to prevent v2.0 upgrades
+
+
+## 1.2.8 - 2021-07-30
+- fix issue with sfneal/mock-models package interdependency
+- bump sfneal/mock-models composer dev requirement min version to v0.8 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
             "role": "Developer"
         }
     ],
-    "version": "1.2.7",
     "require": {
         "php": ">=7.3",
         "sfneal/array-helpers": "^1.3",
@@ -26,7 +25,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.6",
+        "sfneal/mock-models": ">=0.8",
         "sfneal/datum": ">=1.4.1"
     },
     "extra": {


### PR DESCRIPTION
- fix issue with sfneal/mock-models package interdependency
- bump sfneal/mock-models composer dev requirement min version to v0.8