### PR TITLE
Add test methods `AddressBuilderTest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,4 +97,9 @@ All notable changes to `address` will be documented in this file
 
 
 ## 1.2.10 - 2021-08-04
-- bump min sfneal/array-helpers version to v3.0 & refactor use
+- bump min sfneal/array-helpers version to v3.0 & refactor use 
+ 
+
+## 1.2.11 - 2021-09-01
+- add use of dataProviders for testing `AddressBuilder::whereAddressLike()` method
+- add `whereAddressLike()` test method to `AddressBuilderTest`

--- a/src/Builders/AddressBuilder.php
+++ b/src/Builders/AddressBuilder.php
@@ -6,8 +6,6 @@ use Sfneal\Builders\QueryBuilder;
 
 class AddressBuilder extends QueryBuilder
 {
-    // todo: add tests
-
     /**
      * Scope query results to Address's associated with a particular model.
      *

--- a/tests/Feature/AddressBuilderTest.php
+++ b/tests/Feature/AddressBuilderTest.php
@@ -53,7 +53,7 @@ class AddressBuilderTest extends TestCase
                     'city' => 'New York',
                     'state' => 'NY',
                     'zip' => '10065',
-                ]
+                ],
             ],
 
             [
@@ -62,7 +62,7 @@ class AddressBuilderTest extends TestCase
                     'city' => 'Boston',
                     'state' => 'MA',
                     'zip' => '02892',
-                ]
+                ],
             ],
 
             [
@@ -71,7 +71,7 @@ class AddressBuilderTest extends TestCase
                     'city' => 'Chicago',
                     'state' => 'IL',
                     'zip' => '29301',
-                ]
+                ],
             ],
         ];
     }

--- a/tests/Feature/AddressBuilderTest.php
+++ b/tests/Feature/AddressBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Address\Tests\Feature;
 
+use Sfneal\Address\Builders\AddressBuilder;
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Tests\TestCase;
 use Sfneal\Queries\RandomModelAttributeQuery;
@@ -16,5 +17,29 @@ class AddressBuilderTest extends TestCase
         $model = Address::query()->whereType($value)->get();
 
         $this->assertContains($value, $model->pluck($attribute));
+    }
+
+    /** @test  */
+    public function whereAddressLike()
+    {
+        $attributes = [
+            'address_1' => '525 Park Ave',
+            'city' => 'New York',
+            'state' => 'NY',
+            'zip' => '10065',
+        ];
+        $model = Address::factory()->create($attributes);
+
+        $search = '525 Park Ave';
+        $query = Address::query()->whereAddressLike($search);
+        $resultModel = $query->get()->first();
+        $resultAttributes = $query->get(array_keys($attributes))->first()->toArray();
+
+        $this->assertInstanceOf(AddressBuilder::class, $query);
+        $this->assertInstanceOf(Address::class, $resultModel);
+        $this->assertEquals($model->getKey(), $resultModel->getKey());
+        $this->assertNotNull($resultAttributes);
+        $this->assertIsArray($resultAttributes);
+        $this->assertEquals($attributes, $resultAttributes);
     }
 }

--- a/tests/Feature/AddressBuilderTest.php
+++ b/tests/Feature/AddressBuilderTest.php
@@ -19,19 +19,15 @@ class AddressBuilderTest extends TestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test  */
-    public function whereAddressLike()
+    /**
+     * @test
+     * @dataProvider whereAddressLikeProvider
+     */
+    public function whereAddressLike(array $attributes)
     {
-        $attributes = [
-            'address_1' => '525 Park Ave',
-            'city' => 'New York',
-            'state' => 'NY',
-            'zip' => '10065',
-        ];
         $model = Address::factory()->create($attributes);
 
-        $search = '525 Park Ave';
-        $query = Address::query()->whereAddressLike($search);
+        $query = Address::query()->whereAddressLike($attributes['address_1']);
         $resultModel = $query->get()->first();
         $resultAttributes = $query->get(array_keys($attributes))->first()->toArray();
 
@@ -41,5 +37,42 @@ class AddressBuilderTest extends TestCase
         $this->assertNotNull($resultAttributes);
         $this->assertIsArray($resultAttributes);
         $this->assertEquals($attributes, $resultAttributes);
+    }
+
+    /**
+     * Retrieve an array of Address model attributes to use to create models.
+     *
+     * @return array[]
+     */
+    public function whereAddressLikeProvider(): array
+    {
+        return [
+            [
+                [
+                    'address_1' => '525 Park Ave',
+                    'city' => 'New York',
+                    'state' => 'NY',
+                    'zip' => '10065',
+                ]
+            ],
+
+            [
+                [
+                    'address_1' => '420 Broadway St',
+                    'city' => 'Boston',
+                    'state' => 'MA',
+                    'zip' => '02892',
+                ]
+            ],
+
+            [
+                [
+                    'address_1' => '134 Main St',
+                    'city' => 'Chicago',
+                    'state' => 'IL',
+                    'zip' => '29301',
+                ]
+            ],
+        ];
     }
 }


### PR DESCRIPTION
- add use of dataProviders for testing `AddressBuilder::whereAddressLike()` method
- add `whereAddressLike()` test method to `AddressBuilderTest`

fixes #24 