### PR TITLE
`AddressAccessors` model trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ All notable changes to `address` will be documented in this file
 - bump min sfneal/array-helpers version to v3.0 & refactor use 
  
 
-## 1.2.11 - 2021-09-01
+## 1.2.11 - 2021-09-02
 - add use of dataProviders for testing `AddressBuilder::whereAddressLike()` method
 - add `whereAddressLike()` test method to `AddressBuilderTest`
+
+
+## 1.2.12 - 2021-09-02
+- make `AddressAccessors` model trait that adds 'address' model relationship accessors ('address_1', 'city', etc...)

--- a/src/Models/Traits/AddressAccessors.php
+++ b/src/Models/Traits/AddressAccessors.php
@@ -5,11 +5,21 @@ namespace Sfneal\Address\Models\Traits;
 trait AddressAccessors
 {
     /**
+     * Get the 'city_state' attribute.
+     *
+     * @return null|string
+     */
+    public function getCityStateAttribute(): ?string
+    {
+        return $this->address->city_state ?? null;
+    }
+
+    /**
      * Retrieve the User's 'address1' attribute.
      *
-     * @return mixed
+     * @return null|string
      */
-    public function getAddress1Attribute()
+    public function getAddress1Attribute(): ?string
     {
         return $this->address->address_1 ?? null;
     }
@@ -17,9 +27,9 @@ trait AddressAccessors
     /**
      * Retrieve the User's 'address2' attribute.
      *
-     * @return mixed
+     * @return null|string
      */
-    public function getAddress2Attribute()
+    public function getAddress2Attribute(): ?string
     {
         return $this->address->address_2 ?? null;
     }
@@ -27,9 +37,9 @@ trait AddressAccessors
     /**
      * Retrieve the User's 'city' attribute.
      *
-     * @return mixed
+     * @return null|string
      */
-    public function getCityAttribute()
+    public function getCityAttribute(): ?string
     {
         return $this->address->city ?? null;
     }
@@ -37,9 +47,9 @@ trait AddressAccessors
     /**
      * Retrieve the User's 'state' attribute.
      *
-     * @return mixed
+     * @return null|string
      */
-    public function getStateAttribute()
+    public function getStateAttribute(): ?string
     {
         return $this->address->state ?? null;
     }
@@ -47,9 +57,9 @@ trait AddressAccessors
     /**
      * Retrieve the User's 'zip' attribute.
      *
-     * @return mixed
+     * @return null|string
      */
-    public function getZipAttribute()
+    public function getZipAttribute(): ?string
     {
         return $this->address->zip ?? null;
     }

--- a/src/Models/Traits/AddressAccessors.php
+++ b/src/Models/Traits/AddressAccessors.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sfneal\Address\Models\Traits;
+
+trait AddressAccessors
+{
+    /**
+     * Retrieve the User's 'address1' attribute.
+     *
+     * @return mixed
+     */
+    public function getAddress1Attribute()
+    {
+        return $this->address->address_1 ?? null;
+    }
+
+    /**
+     * Retrieve the User's 'address2' attribute.
+     *
+     * @return mixed
+     */
+    public function getAddress2Attribute()
+    {
+        return $this->address->address_2 ?? null;
+    }
+
+    /**
+     * Retrieve the User's 'city' attribute.
+     *
+     * @return mixed
+     */
+    public function getCityAttribute()
+    {
+        return $this->address->city ?? null;
+    }
+
+    /**
+     * Retrieve the User's 'state' attribute.
+     *
+     * @return mixed
+     */
+    public function getStateAttribute()
+    {
+        return $this->address->state ?? null;
+    }
+
+    /**
+     * Retrieve the User's 'zip' attribute.
+     *
+     * @return mixed
+     */
+    public function getZipAttribute()
+    {
+        return $this->address->zip ?? null;
+    }
+}


### PR DESCRIPTION
- make `AddressAccessors` model trait that adds 'address' model relationship accessors ('address_1', 'city', etc...)

resolves #26 